### PR TITLE
Add optional parameters for filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,45 @@ Call the extended filter dynamically
 Filtry::myCustomFilter('some-custom-string');
 ```
 
+#### Optional parameters
+
+You can define optional parameters for your filter.
+
+```php
+<?php
+
+Filtry::extend('custom_filter', function ($data, $param1, $param2) {
+    return $data . ($param1 + $param2);
+});
+```
+
+And then add the parameters in your request:
+
+```php
+<?php
+
+use Mjarestad\Filtry\Http\Requests\Request;
+
+class StorePostRequest extends Request
+{
+    public function rules()
+    {
+        return [
+            'author' => 'required',
+        ];
+    }
+
+    public function filters()
+    {
+        return [
+            'author' => 'custom_param:1,2',
+        ];
+    }
+}
+```
+
+It will concatenate 3 to your author attribute.
+
 ###Standalone
 
 ```php

--- a/tests/FiltryTest.php
+++ b/tests/FiltryTest.php
@@ -4,7 +4,10 @@ use Mjarestad\Filtry\Filtry;
 
 class FiltryTest extends \PHPUnit_Framework_TestCase
 {
-	public $filter;
+	/**
+	 * @var Filtry
+	 */
+	public $filtry;
 
 	public function setUp()
 	{
@@ -154,8 +157,21 @@ class FiltryTest extends \PHPUnit_Framework_TestCase
 			return 'test-string';
 		});
 		$filter = $this->filtry->make(array('attribute' => 'some data'), array('attribute' => 'custom_filter'));
-		$data = $filter->getfiltered();
+		$data = $filter->getFiltered();
 		$this->assertEquals('test-string', $data['attribute']);
+	}
+
+	public function testMakeWithCustomFilterAndParameters()
+	{
+		$this->filtry->extend('custom_filter', function($value, $param1, $param2) {
+			return $value . ($param1 + $param2);
+		});
+		$filter = $this->filtry->make(
+			['attribute' => 'some data'],
+			['attribute' => 'custom_filter:1,2']
+		);
+		$data = $filter->getFiltered();
+		$this->assertEquals('some data3', $data['attribute']);
 	}
 
     public function testGetValuesWithoutFilters()
@@ -163,5 +179,5 @@ class FiltryTest extends \PHPUnit_Framework_TestCase
         $filter = $this->filtry->make(array('attribute_1' => ' value ', 'attribute_2' => ' value '), array('attribute_1' => 'trim'));
         $data = $filter->getFiltered();
         $this->assertEquals(' value ', $data['attribute_2']);
-    } 
+    }
 }


### PR DESCRIPTION
This PR allows to call filters like this : `custom_filter:1,2`

And then the two parameters `1` and `2` are send to the anonymous function.
