### PR TITLE
Bug in Filtry::make()

### DIFF
--- a/src/Mjarestad/Filtry/Filtry.php
+++ b/src/Mjarestad/Filtry/Filtry.php
@@ -54,6 +54,7 @@ class Filtry
 		$this->data 		= $data;
 		$this->filters 		= $this->explodeFilters($filters);
 		$this->recursive 	= $recursive;
+		$this->filteredData	= array();
 
 		return $this;
 	}
@@ -66,7 +67,7 @@ class Filtry
 	{
 		$this->filter();
 
-        return array_merge($this->data, $this->filteredData);
+		return array_merge($this->data, $this->filteredData);
 	}
 
 	/**


### PR DESCRIPTION
Hello,

If use `Filtry::make($input, $filters)->getFiltered()` multiple times, it returns data merged from previous calls. Here is an example tinker session:

```
$php artisan tinker
>dump Filtry::make(['p1'=>'a'], ['p1'=>'trim'])->getFiltered()
array(1) {
  ["p1"]=>
  string(1) "a"
}
>dump Filtry::make(['p2'=>'a'], ['p2'=>'trim'])->getFiltered()
array(2) {
  ["p2"]=>
  string(1) "a"
  ["p1"]=>
  string(1) "a"
}
```

Note that the second usage of Filtry returns `p1` which has not been passed.

So I'm suggesting a patch which solves the bug.
