### PR TITLE
Use singleton instead of removed share method

### DIFF
--- a/src/Mjarestad/Filtry/FiltryServiceProviderLaravel5.php
+++ b/src/Mjarestad/Filtry/FiltryServiceProviderLaravel5.php
@@ -12,7 +12,7 @@ class FiltryServiceProviderLaravel5 extends ServiceProvider
      */
     public function register()
     {
-        $this->app['filtry'] = $this->app->share(function($app) {
+        $this->app->singleton('filtry', function($app) {
             return new Filtry;
         });
     }


### PR DESCRIPTION
https://laravel.com/docs/5.4/upgrade

The `share` method was removed in 5.4, you should use `singleton` instead.